### PR TITLE
add missing stdint include to file_utils.h

### DIFF
--- a/webrtc/modules/audio_processing/transient/file_utils.h
+++ b/webrtc/modules/audio_processing/transient/file_utils.h
@@ -12,6 +12,7 @@
 #define MODULES_AUDIO_PROCESSING_TRANSIENT_FILE_UTILS_H_
 
 #include <string.h>
+#include <stdint.h>
 
 #include "rtc_base/system/file_wrapper.h"
 


### PR DESCRIPTION
this missing header caused errors during compilation from the Dockerfile in `docker_vosk`